### PR TITLE
CORS support in test server & helper

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -29,6 +29,12 @@ task 'test', 'run Mocha tests', ->
   spawn "mocha test/config -r should --growl -t 10000 -R list", ->
     spawn "mocha test/integration -r should --growl -t 10000 -R list"
 
+task 'test:servers', 'run app in NODE_ENV=test and fake api server', ->
+  spawn 'cake assets:fast', ->
+    require './test/api/server.coffee'
+    process.env.NODE_ENV = 'test'
+    require './app.coffee'
+
 spawn = (command, callback = (->)) ->
   args = command.split(" ")
   child = child_process.spawn args[0], _.rest(args),

--- a/test/api/server.coffee
+++ b/test/api/server.coffee
@@ -2,6 +2,21 @@ express = require('express')
 
 module.exports = api = express()
 
+# ## CORS middleware
+# 
+# see: http://stackoverflow.com/questions/7067966/how-to-allow-cors-in-express-nodejs
+allowCrossDomain = (req, res, next) ->
+  res.header "Access-Control-Allow-Origin", "*"
+  res.header "Access-Control-Allow-Methods", "GET,PUT,POST,DELETE"
+  res.header "Access-Control-Allow-Headers", "Content-Type, Authorization"
+  
+  # intercept OPTIONS method
+  if "OPTIONS" is req.method
+    res.send 200
+  else
+    next()
+api.use allowCrossDomain
+
 api.get '/status/system', (req, res) ->
   console.log "RETURNING"
   res.send { status: { id: 'system', message: 'ok' } }


### PR DESCRIPTION
I'm not sure what is failing in tests, but I needed to debug the test servers by running `NODE_ENV=test coffee app.coffee` and `coffee test/api/server.coffee` then opening localhost:5000. This showed me an Ember Data "route loading" error being thrown because of a cross-domain restriction.

Since Zombie is server-side and uses [request](https://github.com/mikeal/request) underneath it shouldn't be restricted by the cross-origin browser restriction. So that wasn't the problem.

Regardless this should be helpful if you need to debug integration tests, just run `cake test:servers` and see what your integration specs are looking at.

Unfortunately it seems like something else is happening, potentially at the Ember-data level. If it's any help client-side javascript console.logs should output to stdout (that's why you can see "Expecting API server on http://localhost:5001 ... Fetching status ...") but to get a full output you'll want to run zombie with `debug: true` or `DEBUG=true mocha`.
